### PR TITLE
Arrays of json objects

### DIFF
--- a/OSJSON/OSJSON.h
+++ b/OSJSON/OSJSON.h
@@ -61,11 +61,32 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)intValueForKey:(NSString *)key;
 
 /**
- *  Get an array from the root dictionary
+ *  Get an array from the root dictionary. No type information, so casting required
  *
  *  @param key The key for the value
  */
 - (NSArray *_Nullable)arrayValueForKey:(NSString *)key;
+
+/**
+ *  Get an array of json objects
+ *
+ *  @param key The key for the value
+ */
+- (NSArray<OSJSON *> *_Nullable)jsonArrayForKey:(NSString *)key;
+
+/**
+ *  Get an array of string objects
+ *
+ *  @param key The key for the value
+ */
+- (NSArray<NSString *> *_Nullable)stringArrayForKey:(NSString *)key;
+
+/**
+ *  Get an array of number objects
+ *
+ *  @param key The key for the value
+ */
+- (NSArray<NSNumber *> *_Nullable)numberArrayForKey:(NSString *)key;
 
 /**
  *  Get a child dictionary as an `OSJSON` object from the root dictionary

--- a/OSJSON/OSJSON.m
+++ b/OSJSON/OSJSON.m
@@ -54,7 +54,14 @@
 }
 
 - (NSArray *)arrayValueForKey:(NSString *)key {
-    return [self.rootDictionary objectForKey:key];
+    NSArray *value = [self.rootDictionary objectForKey:key];
+    NSMutableArray *array = [value mutableCopy];
+    [value enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
+        if ([obj isKindOfClass:[NSDictionary class]]) {
+            [array replaceObjectAtIndex:idx withObject:[[OSJSON alloc] initWithObject:obj]];
+        }
+    }];
+    return array;
 }
 
 - (OSJSON *)jsonForKey:(NSString *)key {

--- a/OSJSON/OSJSON.m
+++ b/OSJSON/OSJSON.m
@@ -54,14 +54,24 @@
 }
 
 - (NSArray *)arrayValueForKey:(NSString *)key {
-    NSArray *value = [self.rootDictionary objectForKey:key];
-    NSMutableArray *array = [value mutableCopy];
-    [value enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-        if ([obj isKindOfClass:[NSDictionary class]]) {
-            [array replaceObjectAtIndex:idx withObject:[[OSJSON alloc] initWithObject:obj]];
-        }
+    return [self.rootDictionary objectForKey:key];
+}
+
+- (NSArray<OSJSON *> *)jsonArrayForKey:(NSString *)key {
+    NSArray *array = [self arrayValueForKey:key];
+    NSMutableArray *results = [NSMutableArray arrayWithCapacity:array.count];
+    [array enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
+        [results addObject:[[OSJSON alloc] initWithObject:obj]];
     }];
-    return array;
+    return results;
+}
+
+- (NSArray<NSNumber *> *)numberArrayForKey:(NSString *)key {
+    return [self arrayValueForKey:key];
+}
+
+- (NSArray<NSString *> *)stringArrayForKey:(NSString *)key {
+    return [self arrayValueForKey:key];
 }
 
 - (OSJSON *)jsonForKey:(NSString *)key {

--- a/OSJSONTests/OSJSONTests.m
+++ b/OSJSONTests/OSJSONTests.m
@@ -50,6 +50,17 @@
     XCTAssertEqualObjects([json arrayValueForKey:@"test"], testArray);
 }
 
+- (void)testItIsPossibleToFetchAnArrayOfJsonObjects {
+    NSData *fixture = [self jsonDataFromFixture:@"{ \"test\": [ {\"key\": \"value\"}, {}, {} ] }"];
+    OSJSON *json = [[OSJSON alloc] initWithData:fixture];
+    NSArray *receivedArray = [json arrayValueForKey:@"test"];
+    for (id object in receivedArray) {
+        XCTAssert([object isKindOfClass:[OSJSON class]]);
+    }
+    OSJSON *first = receivedArray.firstObject;
+    XCTAssertEqualObjects([first stringValueForKey:@"key"], @"value");
+}
+
 - (void)testItIsPossibleToFetchAJSONValueFromADictionary {
     NSData *fixture = [self jsonDataFromFixture:@"{ \"test\": { \"key\": \"value\" }}"];
     OSJSON *json = [[OSJSON alloc] initWithData:fixture];

--- a/OSJSONTests/OSJSONTests.m
+++ b/OSJSONTests/OSJSONTests.m
@@ -53,12 +53,26 @@
 - (void)testItIsPossibleToFetchAnArrayOfJsonObjects {
     NSData *fixture = [self jsonDataFromFixture:@"{ \"test\": [ {\"key\": \"value\"}, {}, {} ] }"];
     OSJSON *json = [[OSJSON alloc] initWithData:fixture];
-    NSArray *receivedArray = [json arrayValueForKey:@"test"];
+    NSArray *receivedArray = [json jsonArrayForKey:@"test"];
     for (id object in receivedArray) {
         XCTAssert([object isKindOfClass:[OSJSON class]]);
     }
     OSJSON *first = receivedArray.firstObject;
     XCTAssertEqualObjects([first stringValueForKey:@"key"], @"value");
+}
+
+- (void)testItIsPossibleToFetchAnArrayOfNumbers {
+    NSData *fixture = [self jsonDataFromFixture:@"{ \"test\": [ 1, 2, 3 ] }"];
+    OSJSON *json = [[OSJSON alloc] initWithData:fixture];
+    NSArray *testArray = @[ @1, @2, @3 ];
+    XCTAssertEqualObjects([json numberArrayForKey:@"test"], testArray);
+}
+
+- (void)testItIsPossibleToFetchAStringArray {
+    NSData *fixture = [self jsonDataFromFixture:@"{ \"test\": [ \"1\", \"2\", \"3\" ] }"];
+    OSJSON *json = [[OSJSON alloc] initWithData:fixture];
+    NSArray *testArray = @[ @"1", @"2", @"3" ];
+    XCTAssertEqualObjects([json stringArrayForKey:@"test"], testArray);
 }
 
 - (void)testItIsPossibleToFetchAJSONValueFromADictionary {


### PR DESCRIPTION
@drhaynes Can you run this through your performance test to see how badly it sucks? We could just assume the array has the same type and just do the conversion for everything. I'm guessing `replaceObjectAtIndex:withObject:` is fairly expensive. And the assumption at parse time would be that everything would be `OSJSON` anyway. And actually, it might be that we actually need a second method, cos this isn't going to please swift's type system at present...
