### PR TITLE
Return nil from init when object is nil

### DIFF
--- a/OSJSON/OSJSON.m
+++ b/OSJSON/OSJSON.m
@@ -21,6 +21,9 @@
 @implementation OSJSON
 
 - (instancetype)initWithObject:(NSObject *)object {
+    if (object == nil) {
+        return nil;
+    }
     if ((self = [super init])) {
         _root = object;
     }

--- a/OSJSONTests/OSJSONTests.m
+++ b/OSJSONTests/OSJSONTests.m
@@ -111,4 +111,12 @@
     XCTAssertEqual([json doubleValueForKey:@"test"], 0);
 }
 
+- (void)testInitWithInvalidJsonDataReturnsANilOSJSON {
+    NSString *badJson = @"<!:@";
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:badJson
+                                                       options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    OSJSON *json = [[OSJSON alloc] initWithData:data];
+    XCTAssertNil(json);
+}
+
 @end


### PR DESCRIPTION
This allows us fail reliably when our data is nil on init, like this:

<img width="482" alt="screenshot 2016-03-11 16 05 39" src="https://cloud.githubusercontent.com/assets/117291/13707864/a5f759e6-e7a3-11e5-8a38-dc38cb391cde.png">
