### PR TITLE
Return nil from jsonArrayForKey: when the underlying array is nil

### DIFF
--- a/OSJSON/OSJSON.m
+++ b/OSJSON/OSJSON.m
@@ -71,6 +71,9 @@
 
 - (NSArray<OSJSON *> *)jsonArrayForKey:(NSString *)key {
     NSArray *array = [self arrayValueForKey:key];
+    if (array == nil) {
+        return nil;
+    }
     NSMutableArray *results = [NSMutableArray arrayWithCapacity:array.count];
     [array enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
         [results addObject:[[OSJSON alloc] initWithObject:obj]];

--- a/OSJSONTests/OSJSONTests.m
+++ b/OSJSONTests/OSJSONTests.m
@@ -129,5 +129,11 @@
     XCTAssertNil([json arrayValueForKey:@"test"]);
 }
 
+- (void)testJsonArrayForKeyReturnsNilIfNoArrayPresent {
+    NSData *fixture = [self jsonDataFromFixture:@"{ \"test\": { \"key\": \"value\" }}"];
+    OSJSON *json = [[OSJSON alloc] initWithData:fixture];
+    XCTAssertNil([json jsonArrayForKey:@"test"]);
+}
+
 
 @end


### PR DESCRIPTION
Before this fix, if the array from `arrayValueForKey:` was nil, a call to `jsonArrayForKey:` would return an empty array, rather than nil as expected.
